### PR TITLE
add timestamps for topics and additional links

### DIFF
--- a/podcast/the-changelog-301.md
+++ b/podcast/the-changelog-301.md
@@ -1,4 +1,49 @@
+## Topic Timestamps
+2:22
+- The history of Python at Microsoft
+
+3:15
+- The origination of IronPython
+
+4:05
+- Python tools for Visual Studio
+
+7:54
+- What Microsoft is doing with Python
+
+10:22
+- Why Python is good for people new to programming
+
+12:20
+- Pythonic
+
+13:52
+- PEP 8
+
+15:47
+- Black
+
+18:16
+- Pylint
+
+21:41
+- CPython
+
+26:01
+- Opensource at Microsoft
+
+28:29
+- The future of Python
+
+33:55
+- The latest in Python
+
+## Links
 - [IronPython](http://ironpython.net/)
 - [Python Visual Studio](https://www.visualstudio.com/vs/features/python/)
+- [Python Visual Studio Code extension](https://code.visualstudio.com/docs/languages/python)
 - [Black – the uncompromising Python code formatter](https://github.com/ambv/black)
 - [Pylint](https://www.pylint.org/)
+- [CPython](https://github.com/python/cpython)
+- [Jupyter Notebooks](https://notebooks.azure.com/help/jupyter-notebooks)
+- [Visual Studio Team Services](https://visualstudio.microsoft.com/team-services/)


### PR DESCRIPTION
I added topics and their timestamps. You don't have it in other show notes, but I think some people find them helpful. Feel free to remove if it detracts from formatting.