### PR TITLE
Update link to micro user-serv

### DIFF
--- a/gotime/go-time-68.md
+++ b/gotime/go-time-68.md
@@ -1,7 +1,7 @@
 
 [Sourcegraph - Idiomatic Go](https://about.sourcegraph.com/go/idiomatic-go/)
 
-[micro user-serv — db.go](https://github.com/micro/user-srv/blob/master/db/db.go)
+[microhq user-serv — db.go](https://github.com/microhq/user-srv/blob/master/db/db.go)
 
 [jsgo](https://github.com/dave/jsgo)
 


### PR DESCRIPTION
For [episode 68](https://changelog.com/gotime/68). Repositository for `user-serv` has been migrated from `micro/user-serv` to `microhq/user-srv`.