### PR TITLE
Updated aXe links to new domain

### DIFF
--- a/jsparty/js-party-36.md
+++ b/jsparty/js-party-36.md
@@ -1,5 +1,5 @@
-- [Easy Accessibility Testing with aXe](https://axe-core.org/)
-- [aXe Future Tools](https://axe-core.org/coconut/)
+- [Easy Accessibility Testing with aXe](https://www.deque.com/axe/)
+- [aXe Future Tools](https://www.deque.com/axe/axe-for-web/early-release/)
 - [a11y | Join us on Slack!](https://web-a11y.herokuapp.com/)
 - [tota11y – an accessibility visualization toolkit](http://khan.github.io/tota11y/)
 - [GitHub - reactjs/react-a11y: Identifies accessibility issues in your React.js elements](https://github.com/reactjs/react-a11y)

--- a/jsparty/js-party-58.md
+++ b/jsparty/js-party-58.md
@@ -1,7 +1,7 @@
 #### Standards & Opening the Black Box
 
 * [TC39](https://github.com/tc39) on GitHub
-* [Miles Borins](https://twitter.com/mylesborins?lang=en)
+* [Myles Borins](https://twitter.com/mylesborins?lang=en)
 * [Daniel Ehrenberg](https://twitter.com/littledan?lang=en)
 * [Maggie Pint](https://twitter.com/maggiepint?lang=en)
 * [TC39 proposals](https://github.com/tc39/proposals)


### PR DESCRIPTION
Updated aXe links in JS Party episode 36 so that they are going directly to the new domain. Also fixed the spelling of Myles Borins name in JS Party episode 58. (#3)