### PR TITLE
Add reference to Hangar to Practical AI show notes

### DIFF
--- a/practicalai/practical-ai-53.md
+++ b/practicalai/practical-ai-53.md
@@ -1,3 +1,4 @@
 - [Redis](https://redis.io/)
 - [Redis modules](https://redis.io/modules)
 - [RedisAI](https://oss.redislabs.com/redisai/)
+- [Hangar](https://buildmedia.readthedocs.org/media/pdf/hangar-py/latest/hangar-py.pdf)


### PR DESCRIPTION
This was previously an unintelligible in the transcript, but Pieter mentioned it was worth checking out, so seemed helpful to include in the show notes as well. 