### PR TITLE
Add link in Go Time 105: cluster bleep talk by Kris Nova

### DIFF
--- a/gotime/go-time-105.md
+++ b/gotime/go-time-105.md
@@ -1,2 +1,3 @@
 - [Kubernetes.io](https://kubernetes.io/)
 - [Heptio is now part of VMware](https://heptio.cloud.vmware.com/)
+- ["You Can't Have a Cluster \[BLEEP\] Without a Cluster"](https://www.youtube.com/watch?v=CLVIbCs2VJY)


### PR DESCRIPTION
I was lucky to find the video as the top result for "cluster bleep" on YouTube, so I've copied over the link and title.

I really hope the nested square brackets in the video title don't break any markdown renderer on the site.