### PR TITLE
[podcast/the-changelog-375] Set link for Tanka project

### DIFF
--- a/podcast/the-changelog-375.md
+++ b/podcast/the-changelog-375.md
@@ -12,7 +12,7 @@ See also: [Gerhard goes to KubeCon (part 1)](https://changelog.com/podcast/374)
 
 - [Grafana's website](https://grafana.com)
 - [Cortex](https://cortexmetrics.io)
-- [Tanker](https://tanker.io)
+- [Tanka](https://tanka.dev)
 
 #### Crossplane
 


### PR DESCRIPTION
This commit adds the correct link to the [Tanka project](https://tanka.dev) disscussed in the Grafana part of the episode.