### PR TITLE
Corrected link to backend roadmap image

### DIFF
--- a/jsparty/js-party-159.md
+++ b/jsparty/js-party-159.md
@@ -2,4 +2,4 @@
 - [Developer Roadmap website](https://roadmap.sh)
 - [Developer Roadmap on GitHub](https://github.com/kamranahmedse/developer-roadmap)
 - [The Frontend Roadmap image](https://github.com/kamranahmedse/developer-roadmap/blob/master/img/frontend.png)
-- [The Backend Roadmap image](https://github.com/kamranahmedse/developer-roadmap/blob/master/img/frontend.png)
+- [The Backend Roadmap image](https://github.com/kamranahmedse/developer-roadmap/blob/master/img/backend.png)


### PR DESCRIPTION
It was pointing to the frontend roadmap image actually. 😉

Thanks for the awesome podcasts, guys! 🥇 