### PR TITLE
Fix link markdown

### DIFF
--- a/gotime/go-time-168.md
+++ b/gotime/go-time-168.md
@@ -3,7 +3,7 @@ The proposals discussed in this episode are:
 - 20733 - [Redefine range loop variables in each iteration](https://github.com/golang/go/issues/20733)
 - 12854 - [Type inferred composite literals](https://github.com/golang/go/issues/12854)
 - 35304 - [Anonymous struct literals](https://github.com/golang/go/issues/35304)
-- 21496 - [Even narrower: permit type elision in nested composite literals](https://github.com/golang/go/issues/21496 
+- 21496 - [Even narrower: permit type elision in nested composite literals](https://github.com/golang/go/issues/21496)
 - 6386 - [Constants of arbitrary types](https://github.com/golang/go/issues/6386)
 - 27975 - [Immutable type qualifier](https://github.com/golang/go/issues/27975)
 - 29036 - [Make imported symbols predictable](https://github.com/golang/go/issues/29036)


### PR DESCRIPTION
it's just missing a trailing ")"

also the github online editor added a newline.