### PR TITLE
Corrected link to https://uses.tech

### DIFF
--- a/podcast/the-changelog-451.md
+++ b/podcast/the-changelog-451.md
@@ -3,5 +3,5 @@
 - [bat](https://github.com/sharkdp/bat)
 - [fzf](https://github.com/junegunn/fzf)
 - [mcfly](https://github.com/cantino/mcfly)
-- [https://uses.tech](https://uses.tech_
+- [https://uses.tech](https://uses.tech)
 - [NanoVMs let you run your apps faster and safer with Unikernels](https://runninginproduction.com/podcast/79-nanovms-let-you-run-your-apps-faster-and-safer-with-unikernels)


### PR DESCRIPTION
The markdown link was not "closed".