### PR TITLE
Update js-party-186.md

### DIFF
--- a/jsparty/js-party-186.md
+++ b/jsparty/js-party-186.md
@@ -1,6 +1,6 @@
 - [Epic React](https://epicreact.dev/)
 - [React docs](https://reactjs.org/docs/getting-started.html)
-[Getting Closure on React Hooks by Swyx](https://www.swyx.io/hooks/)
+- [Getting Closure on React Hooks by Swyx](https://www.swyx.io/hooks/)
 - [Common Mistakes With React Testing Library](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library)
 - [Soft Skills Podcast](https://softskills.audio/meet-the-hosts/)
 - [Why React Hooks](https://kentcdodds.com/talks/#why-react-hooks)


### PR DESCRIPTION
Minor update to the show notes for episode 186. 

I believe the **"Getting Closure on React Hooks by Swyx"** link, should be it's own `li` and not a continuation of the React Docs `li`. 

<img width="653" alt="Screen Shot 2021-08-06 at 11 35 56 AM" src="https://user-images.githubusercontent.com/50022106/128543132-dd8078f5-cf2c-477a-b5a2-93782ed3bdde.png">
