### PR TITLE
Link to SO post about a Zsh 'reload' function

### DIFF
--- a/podcast/the-changelog-465.md
+++ b/podcast/the-changelog-465.md
@@ -1,5 +1,6 @@
 - [The Changelog #61: Oh My Zsh with Robby Russell](https://changelog.com/podcast/61)
 - [Oh My Zsh](https://ohmyz.sh/)
+- [Reloading Zsh configs with a `reload` command](https://stackoverflow.com/questions/36668910/how-do-i-reload-zsh-config-files-without-replacing-the-current-shell)
 - [ohmyzsh/ohmyzsh/pulls on GitHub](https://github.com/ohmyzsh/ohmyzsh/pulls)
 - [d’Oh My Zsh](https://medium.com/free-code-camp/d-oh-my-zsh-af99ca54212c)
 - [colorize  plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/colorize)


### PR DESCRIPTION
Adam mentions at [18:04](https://changelog.fm/465#t=18:04) in that there's a `reload` command in Zsh, which presumably re-sources all the init scripts, and I don't think there is.

At least it isn't part of default Zsh, or default Oh My Zsh, or an Oh My Zsh plugin.

One of the answers in the Stack Overflow thread linked here does, however, provide a shell function you can use to replicate the function Adam has.