### PR TITLE
Conway's Law mentinoed but actually Goodhart's Law

### DIFF
--- a/jsparty/js-party-242.md
+++ b/jsparty/js-party-242.md
@@ -14,6 +14,6 @@
 #### KBall's Topic
 
 - [How to start a movement](https://www.youtube.com/watch?v=V74AxCqOTvg)
-- [Conway's Law](https://en.wikipedia.org/wiki/Conway%27s_law)
+- ~~[Conway's Law](https://en.wikipedia.org/wiki/Conway%27s_law)~~ [Goodhart's Law](https://en.wikipedia.org/wiki/Goodhart%27s_law)
 - [Cory Wilkerson on The Changelog](https://changelog.fm/459)
 - [The Dip](https://www.amazon.com/Dip-Little-Book-Teaches-Stick/dp/1591841666)


### PR DESCRIPTION
Conway's Law was mentioned but discussion was actually talking about Goodwin's Law. I left the link to Conway's Law because, hey, you did mention it. But did a strikethrough to indicate that wasn't what was actually meant.