### PR TITLE
Add book links for all Practical AI episodes

### DIFF
--- a/practicalai/practical-ai-100.md
+++ b/practicalai/practical-ai-100.md
@@ -14,3 +14,7 @@ Episodes mentioned on the show:
 - [Artificial intelligence at NVIDIA](https://changelog.com/practicalai/15)
 - [Growing up to become a world-class AI expert](https://changelog.com/practicalai/36)
 - [Helping African farmers with TensorFlow](https://changelog.com/practicalai/3)
+
+#### Books
+
+- ["Interpretable Machine Learning" by Christoph Molnar](https://www.amazon.com/dp/0244768528)

--- a/practicalai/practical-ai-107.md
+++ b/practicalai/practical-ai-107.md
@@ -14,5 +14,9 @@ Links relevant to the show:
 - [Jenny Bryan on naming things](https://speakerdeck.com/jennybc/how-to-name-files)
 - [JD Long's talk at rstudio::conf this year about being empathetic](https://resources.rstudio.com/rstudio-conf-2019/putting-empathy-in-action-building-a-community-of-practice-for-analytics-in-a-global-corporation)
 - [python's version of pyprojroot](https://github.com/chendaniely/pyprojroot)
-- [Pandas for everyone book](https://smile.amazon.com/Pandas-Everyone-Analysis-Addison-Wesley-Analytics-ebook/dp/B0789WKTKJ)
 - [“Be kind: all else is details”. -- Greg Wilson, Teaching Teach Together -- The Rules](http://teachtogether.tech/)
+
+#### Books
+
+- ["Pandas for Everyone" by Daniel Chen](https://www.amazon.com/dp/0137891156)
+- ["Advanced R" by Hadley Wickham](https://www.amazon.com/dp/0815384572)

--- a/practicalai/practical-ai-12.md
+++ b/practicalai/practical-ai-12.md
@@ -9,3 +9,7 @@ News/Updates:
 Learning Resources:
 - [Hands on ML books dataviz](https://anvaka.github.io/greview/hands-on-ml/1/)
 - [Udemy - Complete Guide to TensorFlow for Deep Learning with Python](https://www.udemy.com/complete-guide-to-tensorflow-for-deep-learning-with-python)
+
+#### Books
+
+- ["Hands-On Machine Learning" by Aurélien Géron](https://www.amazon.com/dp/1492032646)

--- a/practicalai/practical-ai-126.md
+++ b/practicalai/practical-ai-126.md
@@ -1,3 +1,6 @@
-- [Tuning Up: From A/B testing to Bayesian optimization](https://www.manning.com/books/tuning-up-from-a-b-testing-to-bayesian-optimization)
-- [Tuning Up | GitHub](https://github.com/tuningup/tuningup)
-- Manning 40% discount code: podpracticalAI19
+
+#### Books
+
+- ["Experimentation for Engineers" by David Sweet](https://www.manning.com/books/experimentation-for-engineers)
+  - [Tuning Up | GitHub](https://github.com/tuningup/tuningup)
+  - Manning 40% discount code: podpracticalAI19

--- a/practicalai/practical-ai-127.md
+++ b/practicalai/practical-ai-127.md
@@ -1,3 +1,7 @@
 - [Women in Data Science (WiDS) Worldwide Initiative](https://www.widsconference.org)
 - [WiDS Podcast](https://www.widsconference.org/podcast.html)
 - [WiDS 2020 Opening Video](https://www.youtube.com/watch?v=DrLNUBipwdQ)
+
+#### Books
+
+- ["Mindset" by Carol S. Dweck](https://www.amazon.com/dp/0345472322)

--- a/practicalai/practical-ai-135.md
+++ b/practicalai/practical-ai-135.md
@@ -4,3 +4,7 @@
 - [Jax](https://github.com/google/jax)
 - [Livebook demo on YouTube](https://www.youtube.com/watch?v=RKvqc-UEe34)
 - [Erlang Ecosystem Foundation](https://erlef.org)
+
+#### Books
+
+- ["Genetic Algorithms in Elixir" by Sean Moriarity](https://www.amazon.com/dp/168050794X)

--- a/practicalai/practical-ai-137.md
+++ b/practicalai/practical-ai-137.md
@@ -1,5 +1,8 @@
 - [High-performance speech recognition with no supervision at all](https://ai.facebook.com/blog/wav2vec-unsupervised-speech-recognition-without-supervision/)
-- [Meta Learning: How To Learn Deep Learning And Thrive In The Digital World](https://gumroad.com/l/learn_deep_learning)
 - [deeplearning.ai MLOps course](https://www.deeplearning.ai/program/machine-learning-engineering-for-production-mlops/)
 - [GitHub MLOps resources](https://mlops.githubapp.com/)
-- ["Cracking the Data Code" book](https://www.amazon.com/Cracking-Data-Code-Unlock-organisation-ebook/dp/B07KHVPNZL)
+
+#### Books
+
+- ["Cracking The Data Code" by Mike Bugembe](https://www.amazon.com/dp/1781333335)
+- ["Meta Learning" by Radek Osmulski](https://rosmulski.gumroad.com/l/learn_machine_learning)

--- a/practicalai/practical-ai-14.md
+++ b/practicalai/practical-ai-14.md
@@ -3,6 +3,10 @@
 - [OpenAI blog](https://blog.openai.com/)
 - [The Dota playing team of AIs from OpenAI](https://blog.openai.com/openai-five/)
 - [Microsoft Tay Chatbot](https://en.wikipedia.org/wiki/Tay_(bot))
-- [Reinforcement learning book](https://mitpress.mit.edu/books/reinforcement-learning)
 - [Reinforcement learning Wikipedia](https://en.wikipedia.org/wiki/Reinforcement_learning)
 - [Berkeley course CS294-112 on Reinforcement learning](http://rail.eecs.berkeley.edu/deeprlcourse/). Includes pdf notes and [YouTube videos](https://www.youtube.com/playlist?list=PLkFD6_40KJIxJMR-j5A1mkxK26gh_qg37) of the lectures.
+
+#### Books
+
+- ["Deep Learning" by Ian Goodfellow, Yoshua Bengio and Aaron Courville](https://www.amazon.com/dp/0262035618)
+- ["Reinforcement Learning: An Introduction" by Richard S. Sutton and Andrew G. Barto](https://www.amazon.com/dp/0262039249)

--- a/practicalai/practical-ai-140.md
+++ b/practicalai/practical-ai-140.md
@@ -1,3 +1,7 @@
 - [ACM article: "Deep Learning for AI"](https://cacm.acm.org/magazines/2021/7/253464-deep-learning-for-ai/fulltext)
 - [GitHub Copilot](https://copilot.github.com/)
-- [Book: Human in the loop machine learning](https://www.manning.com/books/human-in-the-loop-machine-learning) (use **podpracticalAI19** for 40% off)
+
+#### Books
+
+- ["Human-in-the-Loop Machine Learning" by Robert (Munro) Monarch](https://www.manning.com/books/human-in-the-loop-machine-learning) (use **podpracticalAI19** for 40% off)
+- ["A Thousand Brains" by Jeff Hawkins](https://www.amazon.com/dp/1541675797)

--- a/practicalai/practical-ai-142.md
+++ b/practicalai/practical-ai-142.md
@@ -1,3 +1,6 @@
 - ["Building a data team at a mid-stage startup: a short story" by Erik Bernhardsson](https://erikbern.com/2021/07/07/the-data-team-a-short-story.html)
-- ["Cracking the data code" by Mike Bugembe](https://www.amazon.com/Cracking-Data-Code-Unlock-organisation-ebook/dp/B07KHVPNZL)
-- ["Data Driven" by DJ Patel and Hilary Mason](https://www.amazon.com/Data-Driven-DJ-Patil-ebook/dp/B00SXHFTAS)
+
+#### Books
+
+- ["Cracking The Data Code" by Mike Bugembe](https://www.amazon.com/dp/1781333335)
+- ["Data Driven" by DJ Patil and Hilary Mason](https://www.amazon.com/dp/B00SXHFTAS)

--- a/practicalai/practical-ai-146.md
+++ b/practicalai/practical-ai-146.md
@@ -4,4 +4,7 @@
 - [A New AI Lexicon: Smart](https://medium.com/a-new-ai-lexicon/a-new-ai-lexicon-smart-580484078624)
 - [A New AI Lexicon: Artificial Identity Cataracts](https://medium.com/a-new-ai-lexicon/a-new-ai-lexicon-artificial-identity-cataracts-29f73c32e6bb)
 - [A New AI Lexicon: Imbrication](https://medium.com/a-new-ai-lexicon/a-new-ai-lexicon-imbrication-40b380dafa35)
-- [Free 500+ PDF "Applications of Deep Learning" book from Jeff Heaton, who is teaching this course at Washington University in St. Louis ](https://t.co/0ZQ27vTx7O?amp=1)
+
+#### Books
+
+- [Free 500+ PDF "Applications of Deep Neural Networks with Keras" book from Jeff Heaton, who is teaching this course at Washington University in St. Louis](https://arxiv.org/pdf/2009.05673.pdf)

--- a/practicalai/practical-ai-150.md
+++ b/practicalai/practical-ai-150.md
@@ -1,3 +1,6 @@
 - [Metaflow](https://metaflow.org/)
-- [Ville's book "Effective Data Science Infrastructure"](https://www.manning.com/books/effective-data-science-infrastructure)
-    - Use code **podpracticalAI19** for 40% off!
+
+#### Books
+
+- ["Effective Data Science Infrastructure" by Ville Tuulos](https://www.manning.com/books/effective-data-science-infrastructure)
+  - Use code **podpracticalAI19** for 40% off!

--- a/practicalai/practical-ai-152.md
+++ b/practicalai/practical-ai-152.md
@@ -1,2 +1,5 @@
-- [Mathematics of Machine Learning](https://tivadar.gumroad.com/l/mathematics-of-machine-learning)
 - [Mathematics of Machine Learning - Roadmap Graphic | Twitter](https://twitter.com/TivadarDanka/status/1426158532311896067)
+
+#### Books
+
+- ["Mathematics of Machine Learning" by Tivadar Danka](https://tivadar.gumroad.com/l/mathematics-of-machine-learning)

--- a/practicalai/practical-ai-168.md
+++ b/practicalai/practical-ai-168.md
@@ -2,3 +2,8 @@
 - [DeepMind says its new AI coding engine is as good as an average human programmer](https://www.theverge.com/2022/2/2/22914085/alphacode-ai-coding-program-automatic-deepmind-codeforce)
 - [Artificial intelligence system rapidly predicts how two proteins will attach](https://news.mit.edu/2022/ai-predicts-protein-docking-0201)
 - [Seeing Theory](https://seeing-theory.brown.edu)
+
+#### Books
+
+- ["The Art of Doing Science and Engineering" by Richard W. Hamming](https://www.amazon.com/dp/1732265178)
+- ["Patterns, Predictions, and Actions" by Moritz Hardt and Benjamin Recht](https://www.amazon.com/dp/069123373X)

--- a/practicalai/practical-ai-171.md
+++ b/practicalai/practical-ai-171.md
@@ -1,4 +1,7 @@
 #### Learning Resources
 
 - [Go.Dev](https://go.dev) - a great programming language for data fabric development
-- [Python Data Science Handbook](https://jakevdp.github.io/PythonDataScienceHandbook)
+
+#### Books
+
+- ["Python Data Science Handbook" by Jake VanderPlas](https://jakevdp.github.io/PythonDataScienceHandbook)

--- a/practicalai/practical-ai-197.md
+++ b/practicalai/practical-ai-197.md
@@ -1,6 +1,8 @@
 Use the code **podpracticalAI19** for 40% off of [Data for All](https://www.manning.com/books/data-for-all), along with all Manning products in all formats!!!
 
-- [Data for All](https://www.manning.com/books/data-for-all)
+#### Books
+
+- ["Data for All" by John K. Thompson](https://www.manning.com/books/data-for-all)
 - John's other books:
-    - [Analytics Teams: Harnessing analytics and artificial intelligence for business improvement](https://www.amazon.com/Building-Analytics-Teams-intelligence-improvement/dp/1800203160)
-    - [Analytics: How to win with Intelligence](https://www.amazon.com/Analytics-How-Intelligence-John-Thompson/dp/1634622375)
+  - ["Building Analytics Teams" by John K. Thompson](https://www.amazon.com/dp/1800203160)
+  - ["Analytics" by John Thompson and Shawn Rogers](https://www.amazon.com/dp/1634622375)

--- a/practicalai/practical-ai-2.md
+++ b/practicalai/practical-ai-2.md
@@ -1,2 +1,5 @@
 - [MachineBox](https://machinebox.io/)
-- [Go Programming Blueprints: Second Edition](https://www.amazon.com/Programming-Blueprints-real-world-production-ready-cutting-edge/dp/1786468948/ref=sr_1_3?s=books&ie=UTF8&qid=1541012061&sr=1-3&keywords=go+programming+blueprints)
+
+#### Books
+
+- ["Go Programming Blueprints" by Mat Ryer](https://www.amazon.com/dp/1786468948)

--- a/practicalai/practical-ai-202.md
+++ b/practicalai/practical-ai-202.md
@@ -8,3 +8,8 @@ Related to Galactica:
 
 - [Model website](https://galactica.org/)
 - [Article: "Galactica: the AI knowledge base that makes stuff up"](https://www.aiweirdness.com/galactica/)
+
+#### Books
+
+- ["Interpretable Machine Learning" by Christoph Molnar](https://www.amazon.com/dp/0244768528)
+- ["Modeling Mindsets" by Christoph Molnar](https://www.amazon.com/dp/B0BMJH7M9F)

--- a/practicalai/practical-ai-203.md
+++ b/practicalai/practical-ai-203.md
@@ -3,3 +3,7 @@
 - [Azure Architecture Center](https://learn.microsoft.com/en-us/azure/architecture/)
 - [SIL International](https://www.sil.org/)
 - [The bloom-captioning dataset](https://huggingface.co/datasets/sil-ai/bloom-captioning)
+
+#### Books
+
+- ["Applied Machine Learning and AI for Engineers" by Jeff Prosise](https://www.amazon.com/dp/B0BM35KY4C)

--- a/practicalai/practical-ai-22.md
+++ b/practicalai/practical-ai-22.md
@@ -18,4 +18,7 @@ News/Discussion:
 Learning resources:
 
 - [The Backpropagation Algorithm Demystified](https://medium.com/@nathaliejeans7/the-backpropagation-algorithm-demystified-41b705229727)
-- [Grokking Deep Learning](https://github.com/iamtrask/Grokking-Deep-Learning)
+
+#### Books
+
+- ["Grokking Deep Learning" by Andrew Trask](https://github.com/iamtrask/Grokking-Deep-Learning)

--- a/practicalai/practical-ai-28.md
+++ b/practicalai/practical-ai-28.md
@@ -10,8 +10,9 @@
 
 #### Books
 
-- [Deep Learning textbook](http://www.deeplearningbook.org) by Ian Goodfellow, Yoshua Bengio, and Aaron Courville
-- [Machine Learning With Go](https://www.packtpub.com/big-data-and-business-intelligence/machine-learning-go) by Daniel Whitenack
+- ["Deep Learning" by Ian Goodfellow, Yoshua Bengio, and Aaron Courville](http://www.deeplearningbook.org)
+- ["Natural Language Processing with PyTorch" by Delip Rao and Brian McMahan](https://www.amazon.com/dp/1491978236)
+- ["Machine Learning With Go" by Daniel Whitenack and Janani Selvaraj](https://www.amazon.com/dp/1789619890)
 
 (Daniel is too humble to put his own book in this list, so Chris inserted it above without Daniel's knowledge - because it's a damn fine book!)
 

--- a/practicalai/practical-ai-34.md
+++ b/practicalai/practical-ai-34.md
@@ -19,3 +19,7 @@ References / notes:
 - [SUMMARY OF THE 2018 DEPARTMENT OF DEFENSE ARTIFICIAL INTELLIGENCE STRATEGY: Harnessing AI to Advance Our Security and Prosperity](https://media.defense.gov/2019/Feb/12/2002088963/-1/-1/1/SUMMARY-OF-DOD-AI-STRATEGY.PDF)
 - [Artificial Intelligence Is Now a Pentagon Priority. Will Silicon Valley Help?](https://www.nytimes.com/2018/08/26/technology/pentagon-artificial-intelligence.html)
 - [DOD Takes Strategic Approach to Artificial Intelligence](https://www.defense.gov/explore/story/Article/1755991/dod-takes-strategic-approach-to-artificial-intelligence)
+
+#### Books
+
+- ["AI Superpowers" by Kai-Fu Lee](https://www.amazon.com/dp/0358105587)

--- a/practicalai/practical-ai-46.md
+++ b/practicalai/practical-ai-46.md
@@ -1,3 +1,6 @@
 - [Distill.pub by Andreas](https://distill.pub/2019/memorization-in-rnns/)
-- [Programming collective intelligence](https://www.amazon.com/Programming-Collective-Intelligence-Building-Applications/dp/0596529325)
 - [Taylor approximation and other mathematics related to neural networks](https://medium.com/@rajarshi.banerjee47/the-mathematics-of-neural-networks-5af71963e538)
+
+#### Books
+
+- ["Programming Collective Intelligence" by Toby Segaran](https://www.amazon.com/dp/0596529325)

--- a/practicalai/practical-ai-48.md
+++ b/practicalai/practical-ai-48.md
@@ -1,4 +1,8 @@
 - [Seldon](https://www.seldon.io/)
 - [Seldon Core](https://github.com/SeldonIO/seldon-core)
 - [Alibi](https://github.com/SeldonIO/alibi)
-- [Christoph Molnar's book, "Interpretable Machine Learning"](https://christophm.github.io/interpretable-ml-book/)
+
+#### Books
+
+- ["The Foundation Series" by Isaac Asimov](https://www.amazon.com/dp/B01EFDEMS8)
+- ["Interpretable Machine Learning" by Christoph Molnar](https://christophm.github.io/interpretable-ml-book/)

--- a/practicalai/practical-ai-50.md
+++ b/practicalai/practical-ai-50.md
@@ -2,8 +2,8 @@ Learn more about neural networks with the following learning resources.
 
 #### Books
 
-- [Deep Learning textbook](https://www.deeplearningbook.org)
-- [Data Science from Scratch, 2nd Edition](https://learning.oreilly.com/library/view/data-science-from/9781492041122/)
+- ["Deep Learning" by Ian Goodfellow, Yoshua Bengio, and Aaron Courville](http://www.deeplearningbook.org)
+- ["Data Science from Scratch" by Joel Grus](https://learning.oreilly.com/library/view/data-science-from/9781492041122/)
 - There are literally too many others to name...
 
 #### Online Courses

--- a/practicalai/practical-ai-51.md
+++ b/practicalai/practical-ai-51.md
@@ -1,8 +1,11 @@
 - [Allen AI](https://allenai.org/)
 - [AllenNLP](https://allennlp.org/)
 - [AllenNLP demo website](https://demo.allennlp.org)
-- [Data Science from Scratch 2nd edition](https://learning.oreilly.com/library/view/data-science-from/9781492041122/)
 - [Writing Code for NLP Research​](https://docs.google.com/presentation/d/17NoJY2SnC2UMbVegaRCWA7Oca7UCZ3vHnMqBV4SUayc/edit?usp=sharing)
 - [I don't like Notebooks](https://docs.google.com/presentation/d/1n2RlMdmv1p25Xy5thJUhkKGvjtV-dkAIsUXP-AL4ffI/edit?usp=sharing)
 - [Joel's website](https://joelgrus.com)
 - [Adversarial learning podcast](http://adversariallearning.com/)
+
+#### Books
+
+- ["Data Science from Scratch" by Joel Grus](https://learning.oreilly.com/library/view/data-science-from/9781492041122/)

--- a/practicalai/practical-ai-52.md
+++ b/practicalai/practical-ai-52.md
@@ -20,3 +20,8 @@ Relevant learning resources:
     - [Advanced NLP with spacy:](https://course.spacy.io/)
     - [New fast.ai course! A Code-First Introduction to NLP:](https://www.fast.ai/2019/07/08/fastai-nlp/)
 - [Google Cloud - Deep Learning Containers](https://cloud.google.com/ai-platform/deep-learning-containers)
+
+#### Books
+
+- ["The Pragmatic Programmer" by David Thomas and Andrew Hunt](https://www.amazon.com/dp/0135957052)
+- ["Data Science from Scratch" by Joel Grus](https://www.amazon.com/dp/1492041130)

--- a/practicalai/practical-ai-54.md
+++ b/practicalai/practical-ai-54.md
@@ -1,2 +1,6 @@
 - [Galvanize](https://www.galvanize.com)
 - [HumAIn Podcast](http://www.humainpodcast.com)
+
+#### Books
+
+- ["The Big Nine" by Amy Webb](https://www.amazon.com/dp/154177373X)

--- a/practicalai/practical-ai-63.md
+++ b/practicalai/practical-ai-63.md
@@ -1,2 +1,6 @@
 - [Heartex](https://www.heartex.ai/)
 - [Label Studio](https://labelstud.io/)
+
+#### Books
+
+- ["Paradigms of Artificial Intelligence Programming" by Peter Norvig](https://www.amazon.com/dp/1558601910)

--- a/practicalai/practical-ai-67.md
+++ b/practicalai/practical-ai-67.md
@@ -1,3 +1,6 @@
-- [GANs in Action Book](https://www.manning.com/books/gans-in-action)
 - [Ian Goodfellow NeurIPS paper 2014](https://papers.nips.cc/paper/5423-generative-adversarial-nets.pdf)
 - [GAN TTS](https://arxiv.org/pdf/1909.11646.pdf)
+
+#### Books
+
+- ["GANs in Action" by Jakub Langr and Vladimir Bok](https://www.manning.com/books/gans-in-action)

--- a/practicalai/practical-ai-7.md
+++ b/practicalai/practical-ai-7.md
@@ -1,3 +1,9 @@
 - [Lander Analytics](https://www.landeranalytics.com/)
 - [New York R Conference](https://www.rstats.nyc/)
 - [New York Open Statistical Programming Meetup](https://nyhackr.org/)
+
+#### Books
+
+- ["R for Everyone" by Jared Lander](https://www.amazon.com/dp/013454692X)
+- ["Applied Predictive Modeling" by Max Kuhn and Kjell Johnson](https://www.amazon.com/dp/1461468485)
+- ["Deep Learning with R" by Francois Chollet and J. J. Allaire](https://www.manning.com/books/deep-learning-with-r-second-edition)

--- a/practicalai/practical-ai-74.md
+++ b/practicalai/practical-ai-74.md
@@ -4,4 +4,7 @@
 - [Papermill](https://papermill.readthedocs.io/en/latest/)
 - [nbdev](https://www.fast.ai/2019/12/02/nbdev/)
 - [nbval](https://github.com/computationalmodelling/nbval)
-- [DevOps for dummies](https://www.amazon.com/DevOps-Dummies-Computer-Tech/dp/1119552222)
+
+#### Books
+
+- ["DevOps For Dummies" by Emily Freeman](https://www.amazon.com/dp/1119552222)

--- a/practicalai/practical-ai-81.md
+++ b/practicalai/practical-ai-81.md
@@ -1,7 +1,11 @@
 <mark>Comment on the episode page for a chance to win a FREE copy of the eBook!</mark> Tell us why you are interested in Data Science and how this book might help you achieve your goals. Our 3 favorite comments will be selected on April 13th!
 
-- [Manning Publications book:  Build a Career in Data Science](https://www.manning.com/books/build-a-career-in-data-science)
-- Be sure to use discount code: **podpracticalAI19**
 - [R Conference | New York City](https://rstats.ai/nyr)
-- [Designing Your Life (book)](https://designingyour.life/the-book)
-- [Designing Your Work Life (book)](https://designingyour.life/designing-your-work-life-book)
+
+#### Books
+
+- ["Build a Career in Data Science" by Emily Robinson and Jacqueline Nolis](https://www.manning.com/books/build-a-career-in-data-science)
+  - Be sure to use discount code: **podpracticalAI19**
+- ["Cracking the Coding Interview" by Gayle Laakmann McDowell](https://www.amazon.com/dp/0984782850)
+- ["Designing Your New Work Life" by Bill Burnett and Dave Evans](https://designingyour.life/designing-your-new-work-life/)
+- ["Designing Your Life" by Bill Burnett and Dave Evans](https://designingyour.life/the-book)

--- a/practicalai/practical-ai-83.md
+++ b/practicalai/practical-ai-83.md
@@ -2,3 +2,7 @@
 - [ESRI - GeoAI Blog](https://medium.com/geoai)
 - [ESRI - YouTube: ArcGIS & Artificial Intelligence (DoD JAIC)](https://www.youtube.com/watch?v=laDc9TKhpdI)
 - [Practical AI #72: How the U.S. military thinks about AI (DoD JAIC)](https://changelog.com/practicalai/72)
+
+#### Books
+
+- ["Pattern Recognition and Machine Learning" by Christopher M. Bishop](https://www.amazon.com/dp/1493938436)

--- a/practicalai/practical-ai-85.md
+++ b/practicalai/practical-ai-85.md
@@ -1,8 +1,11 @@
 - [Stuart Russell on Wikipedia](https://en.wikipedia.org/wiki/Stuart_J._Russell)
 - [Stuart Russell's TED Speaker profile](https://www.ted.com/speakers/stuart_russell)
-- [*Human Compatible: Artificial Intelligence and the Problem of Control*](https://www.amazon.com/Human-Compatible-Artificial-Intelligence-Problem/dp/0525558616)
-- [*Artificial Intelligence: A Modern Approach (4th Edition)*](https://www.amazon.com/Artificial-Intelligence-A-Modern-Approach/dp/0134610997)
 - [*Center for Human-Compatible AI*](https://humancompatible.ai)
 - [Stuart Russell on how to make AI ‘human-compatible’](https://techcrunch.com/2020/03/20/stuart-russell-on-how-to-make-ai-human-compatible)
 - [AI could be a disaster for humanity. A top computer scientist thinks he has the solution.](https://www.vox.com/future-perfect/2019/10/26/20932289/ai-stuart-russell-human-compatible)
 - [Leading AI Luminary Has An Idea To Ensure Humans Remain In Control](https://www.forbes.com/sites/peterhigh/2020/01/13/leading-ai-luminary-has-an-idea-to-ensure-humans-remain-in-control)
+
+#### Books
+
+- ["Artificial Intelligence" by Stuart Russell and Peter Norvig](https://www.amazon.com/dp/0134610997)
+- ["Human Compatible" by Stuart Russell](https://www.amazon.com/dp/0525558632)

--- a/practicalai/practical-ai-88.md
+++ b/practicalai/practical-ai-88.md
@@ -1,0 +1,5 @@
+
+
+#### Books
+
+- ["Data Science from Scratch" by Joel Grus](https://www.amazon.com/dp/1492041130)

--- a/practicalai/practical-ai-9.md
+++ b/practicalai/practical-ai-9.md
@@ -1,3 +1,6 @@
 - [JustGiving](https://www.justgiving.com/)
 - [BJ Fogg’s Behavioral Model](http://www.growthengineering.co.uk/bj-foggs-behavior-model/)
-- Mike's book - link forthcoming
+
+#### Books
+
+- ["Cracking The Data Code" by Mike Bugembe](https://www.amazon.com/dp/1781333335)

--- a/practicalai/practical-ai-92.md
+++ b/practicalai/practical-ai-92.md
@@ -4,3 +4,7 @@
 - [A DARPA Perspective on Artificial Intelligence](https://www.darpa.mil/attachments/AIFull.pdf)
 - [DARPA | Wikipedia](https://en.wikipedia.org/wiki/DARPA)
 - [U.S. Department of Defense Directive 3000.09: Autonomy in Weapon Systems](https://www.esd.whs.mil/Portals/54/Documents/DD/issuances/dodd/300009p.pdf)
+
+#### Books
+
+- ["Thinking, Fast and Slow" by Daniel Kahneman](https://www.amazon.com/dp/0374533555)

--- a/practicalai/practical-ai-96.md
+++ b/practicalai/practical-ai-96.md
@@ -5,3 +5,8 @@
 - [OECD Principles on AI](https://www.oecd.org/going-digital/ai/principles)
 - [Cambridge - The Role and Limits of Principles in AI Ethics: Towards a Focus on Tensions](https://dl.acm.org/doi/pdf/10.1145/3306618.3314289)
 - [Nature - Principles alone cannot guarantee ethical AI](https://www.nature.com/articles/s42256-019-0114-4)
+
+#### Books
+
+- ["Artificial Intelligence" by Stuart Russell and Peter Norvig](https://www.amazon.com/dp/0134610997)
+- ["Human Compatible" by Stuart Russell](https://www.amazon.com/dp/0525558632)


### PR DESCRIPTION
This change adds a books section to each Practical AI episode that had a book mentioned in the transcripts. The book link format for existing books was updated to be more consistent. I also made some trivial changes to whitespace for consistency which is why the diff is so noisy.

Merry Christmas! 🎄🎁