### PR TITLE
Fix: Adds protocol to Open Main Frame Project link.

### DIFF
--- a/podcast/the-changelog-524.md
+++ b/podcast/the-changelog-524.md
@@ -1,2 +1,2 @@
-- [Open Mainframe Project](www.openmainframeproject.org)
+- [Open Mainframe Project](https://www.openmainframeproject.org)
 - [IBM zSystems](https://www.ibm.com/z)


### PR DESCRIPTION
Link previously directed to `https://changelog.com/podcast/www.openmainframeproject.org`, which did not work.  Updated to include the protocol so link will work properly.