### PR TITLE
Removing extra space from link

### DIFF
--- a/jsparty/js-party-267.md
+++ b/jsparty/js-party-267.md
@@ -2,4 +2,4 @@
 - [React server componenets demo app](https://github.com/reactjs/server-components-demo)
 - [React server componenets RFC](https://github.com/reactjs/rfcs/blob/main/text/0188-server-components.md)
 - [Try out React server componenets with Next.js's app router](https://beta.nextjs.org/docs/getting-started)
-- [React's blog to get updates]( https://beta.reactjs.org/blog)
+- [React's blog to get updates](https://beta.reactjs.org/blog)Cancel changes

--- a/jsparty/js-party-267.md
+++ b/jsparty/js-party-267.md
@@ -2,4 +2,4 @@
 - [React server componenets demo app](https://github.com/reactjs/server-components-demo)
 - [React server componenets RFC](https://github.com/reactjs/rfcs/blob/main/text/0188-server-components.md)
 - [Try out React server componenets with Next.js's app router](https://beta.nextjs.org/docs/getting-started)
-- [React's blog to get updates](https://beta.reactjs.org/blog)Cancel changes
+- [React's blog to get updates](https://beta.reactjs.org/blog)


### PR DESCRIPTION
The extra space was causing an invalid link, redirecting to the 404 page.