### PR TITLE
Add Charity Majors post link to Changelog 540

### DIFF
--- a/podcast/the-changelog-540.md
+++ b/podcast/the-changelog-540.md
@@ -4,3 +4,4 @@
 - [The Peter principle](https://en.wikipedia.org/wiki/Peter_principle)
 - [Accelerate: Building and Scaling High Performing Technology Organizations](https://www.amazon.com/Accelerate-Building-Performing-Technology-Organizations/dp/B07BMBYHXL)
 - [Dr. Nicole Forsgren](https://nicolefv.com)
+- [The Engineer/Manager Pendulum](https://charity.wtf/2017/05/11/the-engineer-manager-pendulum/)


### PR DESCRIPTION
Adding a link to the Charity Majors blog post that Sarah referenced