### PR TITLE
Missing link to https://www.promptingguide.ai/

### DIFF
--- a/practicalai/practical-ai-256.md
+++ b/practicalai/practical-ai-256.md
@@ -1,3 +1,4 @@
 - [Gemini](https://gemini.google.com/app)
 - [FCC decision on AI voices](https://www.fcc.gov/document/fcc-makes-ai-generated-voices-robocalls-illegal)
 - [FCC Bans AI Voices in Unsolicited Robocalls](https://www.wsj.com/tech/ai/fcc-bans-ai-artificial-intelligence-voices-in-robocalls-texts-3ea20d9f)
+- [Prompt Engineering Guide](https://www.promptingguide.ai/)


### PR DESCRIPTION
This was mentioned in the recommendations near the end of the episode, but is missing from the show notes.

The transcript overview puts this as chapter 15  at 41:02 https://changelog.com/practicalai/256#t=2462

Unfortunately the link is misspelled in the transcript, too. I'll post a separate PR for that.