### PR TITLE
Add dchart link to go-time-305.md

### DIFF
--- a/gotime/go-time-305.md
+++ b/gotime/go-time-305.md
@@ -4,3 +4,4 @@
 - [decksh: a little language for presentations, visualizations, and information displays](https://github.com/ajstarks/decksh)
 - [W. E. B. Du Bois's Data Portraits: Visualizing Black America](https://www.amazon.com/W-Boiss-Data-Portraits-Visualizing/dp/1616897066)
 - [African American Photographs Assembled for 1900 Paris Exposition](https://www.loc.gov/collections/african-american-photographs-1900-paris-exposition/?c=200&sp=3&st=grid)
+- [dchart: dchart makes charts using deck markup](https://github.com/ajstarks/dchart)


### PR DESCRIPTION
Approaching the end, Anthony mentions `dchart` as a good starting point for trying out visualizations in Go. It isn't the easiest to find so I think a link is useful.