### PR TITLE
Add registry explorer links from Ship It 105

### DIFF
--- a/shipit/ship-it-105.md
+++ b/shipit/ship-it-105.md
@@ -7,6 +7,10 @@
 
 - [RFC 1951](https://www.ietf.org/rfc/rfc1951.txt)
 - [Registry explorer](https://oci.dag.dev/)
+- [ima.ge.cx](https://ima.ge.cx/)
+- [How ima.ge.cx works](https://awsteele.com/blog/2023/12/29/how-ima-ge-cx-works.html)
+- [aidansteele/ima.ge.cx-backend](https://github.com/aidansteele/ima.ge.cx-backend)
+- [circulosmeos/gztool](https://github.com/circulosmeos/gztool)
 - [stargz snapshotter](https://github.com/containerd/stargz-snapshotter)
 - [SOCI](https://github.com/awslabs/soci-snapshotter)
 


### PR DESCRIPTION
This PR will update the show notes to Ship It 105 with links mentioned in the [episode chapter on the registry explorer oci.dag.dev](https://changelog.com/shipit/105#t=2599). Jon mentions a similar tool from Aidan Steele ([ima.ge.cx](https://ima.ge.cx/)) that uses [circulosmeos/gztool](https://github.com/circulosmeos/gztool) to enable random access into a `tar.gz` file without modifying the file. Aidan wrote a blog post about [how ima.ge.cx works](https://awsteele.com/blog/2023/12/29/how-ima-ge-cx-works.html).

Considering that Aidan Steele's implementation inspired Jon to write a poem, I think it would be great to include these links in the show notes.