### PR TITLE
fix broken link in go-time-332.md

### DIFF
--- a/gotime/go-time-332.md
+++ b/gotime/go-time-332.md
@@ -1,1 +1,1 @@
-- [Founder Mode]((https://paulgraham.com/foundermode.html)
+- [Founder Mode](https://paulgraham.com/foundermode.html)


### PR DESCRIPTION
Typo in markdown link syntax. `(( -> (` 