### PR TITLE
Episode 611: Add list of packages ready for free-threaded Python

### DIFF
--- a/podcast/the-changelog-611.md
+++ b/podcast/the-changelog-611.md
@@ -1,2 +1,4 @@
 - [core.py](https://podcasters.spotify.com/pod/show/corepy)
 - [What’s New In Python 3.13](https://docs.python.org/3.13/whatsnew/3.13.html#whatsnew313-jit-compiler)
+- [Free-threaded compatibility status tracking](https://py-free-threading.github.io/tracking/)
+- [🧵 Free-Threaded Wheels](https://hugovk.github.io/free-threaded-wheels/)


### PR DESCRIPTION
As mentioned by @ambv around https://changelog.com/podcast/611#t=2607, here's a couple of lists of packages ready for free-threaded Python.

The first is curated and is more detailed, the second is automated and looks at wheels on PyPI (and I made the second one).
