### PR TITLE
Add Illustrated deepseek note to practical-ai-302

### DIFF
--- a/practicalai/practical-ai-302.md
+++ b/practicalai/practical-ai-302.md
@@ -1,3 +1,4 @@
 - [Daniel's blog post on DeepSeek](https://predictionguard.com/deepseek-blog)
 - [DeepSeek R1 on Hugging Face](https://huggingface.co/collections/deepseek-ai/deepseek-r1-678e1e131c0169c0bc89728d)
 - [DeepSeek](https://www.deepseek.com/)
+- [The Illustrated DeepSeek-R1 by Jay Alammar](https://newsletter.languagemodels.co/p/the-illustrated-deepseek-r1)


### PR DESCRIPTION
I looked in the notes for the link, I think it might have been mentioned that a link to this article will be added in the show notes, but maybe not 🤔 