### PR TITLE
Fix changelog 682

### DIFF
--- a/podcast/the-changelog-682.md
+++ b/podcast/the-changelog-682.md
@@ -77,3 +77,4 @@
 - [Incident.io](https://incident.io/)
 - [Clerk](https://clerk.com/)
 - [Raycast](https://www.raycast.com/)
+- [Vercel](https://vercel.com/)


### PR DESCRIPTION
58:35

> ...when these pen testers went and they tried to hack Spectrum for a week or 8 days, I don't remember, and they came back and they didn't find any major security vulnerabilities. I actually largely credit GraphQL for that. It's GraphQL in combination with actually Vercel, funnily enough, because we weren't doing our own hosting...